### PR TITLE
Upgrade ProItemsRepeater to Avalonia 12.0.0-rc1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,11 @@ jobs:
         run: dotnet build -c Release --no-restore -p:VersionSuffix="${{ needs.build.outputs.version-suffix }}"
 
       - name: Test
-        run: dotnet test -c Release --no-build --logger trx --results-directory artifacts/test
+        run: |
+          ./tests/Avalonia.Controls.ItemsRepeater.UnitTests/bin/Release/net8.0/ProItemsRepeater.UnitTests \
+            --results-directory artifacts/test \
+            --report-xunit-trx \
+            --report-xunit-trx-filename results.trx
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,11 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --logger trx --results-directory artifacts/test
+        run: |
+          ./tests/Avalonia.Controls.ItemsRepeater.UnitTests/bin/Release/net8.0/ProItemsRepeater.UnitTests \
+            --results-directory artifacts/test \
+            --report-xunit-trx \
+            --report-xunit-trx-filename results.trx
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <LangVersion>12.0</LangVersion>
-    <AvaloniaVersion>11.0.0</AvaloniaVersion>
-    <AvaloniaSampleVersion>11.3.9</AvaloniaSampleVersion>
+    <AvaloniaVersion>12.0.0-rc1</AvaloniaVersion>
+    <AvaloniaSampleVersion>12.0.0-rc1</AvaloniaSampleVersion>
     <AvaloniaPublicKey>0024000004800000940000000602000000240000525341310004000001000100c1bba1142285fe0419326fb25866ba62c47e6c2b5c1ab0c95b46413fad375471232cb81706932e1cef38781b9ebd39d5100401bacb651c6c5bbf59e571e81b3bc08d2a622004e08b1a6ece82a7e0b9857525c86d2b95fab4bc3dce148558d7f3ae61aa3a234086902aeface87d9dfdd32b9d2fe3c6dd4055b5ab4b104998bd87</AvaloniaPublicKey>
   </PropertyGroup>
 </Project>

--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -1,8 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>ProItemsRepeater</Product>
-    <VersionPrefix>11.3.9</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionPrefix>12.0.0</VersionPrefix>
+    <VersionSuffix>rc1</VersionSuffix>
     <Copyright>Copyright $([System.DateTime]::Now.ToString(`yyyy`)) &#169; Wiesław Šoltés</Copyright>
     <Authors>Wiesław Šoltés</Authors>
     <Description>ItemsRepeater is a light-weight control to generate and present a collection of items.</Description>

--- a/samples/Avalonia.Controls.ItemsRepeater.Samples/Avalonia.Controls.ItemsRepeater.Samples.csproj
+++ b/samples/Avalonia.Controls.ItemsRepeater.Samples/Avalonia.Controls.ItemsRepeater.Samples.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaSampleVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaSampleVersion)" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaSampleVersion)" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.Controls.ItemsRepeater/Avalonia.Controls.ItemsRepeater.csproj
+++ b/src/Avalonia.Controls.ItemsRepeater/Avalonia.Controls.ItemsRepeater.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Avalonia</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageId>ProItemsRepeater</PackageId>

--- a/src/Avalonia.Controls.ItemsRepeater/Controls/ItemsRepeater.LogicalScrollable.cs
+++ b/src/Avalonia.Controls.ItemsRepeater/Controls/ItemsRepeater.LogicalScrollable.cs
@@ -71,6 +71,10 @@ namespace Avalonia.Controls
 
         Size IScrollable.Viewport => _viewport;
 
+        bool IScrollable.CanHorizontallyScroll => _canHorizontallyScroll;
+
+        bool IScrollable.CanVerticallyScroll => _canVerticallyScroll;
+
         Vector IScrollable.Offset
         {
             get => _offset;

--- a/src/Avalonia.Controls.ItemsRepeater/Controls/SelectingItemsRepeater.cs
+++ b/src/Avalonia.Controls.ItemsRepeater/Controls/SelectingItemsRepeater.cs
@@ -71,8 +71,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="SelectedValueBinding"/> property.
         /// </summary>
-        public static readonly StyledProperty<IBinding?> SelectedValueBindingProperty =
-            AvaloniaProperty.Register<SelectingItemsRepeater, IBinding?>(nameof(SelectedValueBinding));
+        public static readonly StyledProperty<BindingBase?> SelectedValueBindingProperty =
+            AvaloniaProperty.Register<SelectingItemsRepeater, BindingBase?>(nameof(SelectedValueBinding));
 
         /// <summary>
         /// Defines the <see cref="SelectedItems"/> property.
@@ -131,7 +131,7 @@ namespace Avalonia.Controls
         private bool _ignoreContainerSelectionChanged;
         private UpdateState? _updateState;
         private bool _hasScrolledToSelectedItem;
-        private BindingEvaluator<object?>? _selectedValueBindingEvaluator;
+        private RepeaterBindingEvaluator<object?>? _selectedValueBindingEvaluator;
         private bool _isSelectionChangeActive;
 
         public SelectingItemsRepeater()
@@ -218,11 +218,11 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets the <see cref="IBinding"/> instance used to obtain the <see cref="SelectedValue"/> property.
+        /// Gets the <see cref="BindingBase"/> instance used to obtain the <see cref="SelectedValue"/> property.
         /// </summary>
         [AssignBinding]
         [InheritDataTypeFromItems(nameof(ItemsSource))]
-        public IBinding? SelectedValueBinding
+        public BindingBase? SelectedValueBinding
         {
             get => GetValue(SelectedValueBindingProperty);
             set => SetValue(SelectedValueBindingProperty, value);
@@ -486,7 +486,7 @@ namespace Avalonia.Controls
                     return;
                 }
 
-                var value = change.GetNewValue<IBinding?>();
+                var value = change.GetNewValue<BindingBase?>();
                 if (value is null)
                 {
                     SetCurrentValue(SelectedValueProperty, SelectedItem);
@@ -1395,9 +1395,11 @@ namespace Avalonia.Controls
             }
         }
 
-        private BindingEvaluator<object?> GetSelectedValueBindingEvaluator(IBinding binding)
+        private RepeaterBindingEvaluator<object?> GetSelectedValueBindingEvaluator(BindingBase binding)
         {
-            _selectedValueBindingEvaluator ??= new();
+            _selectedValueBindingEvaluator ??= RepeaterBindingEvaluator<object?>.TryCreate(binding)
+                ?? throw new InvalidOperationException("SelectedValueBinding could not be created.");
+
             _selectedValueBindingEvaluator.UpdateBinding(binding);
             return _selectedValueBindingEvaluator;
         }
@@ -1505,7 +1507,7 @@ namespace Avalonia.Controls
             switch (eventArgs.Pointer.Type)
             {
                 case PointerType.Mouse:
-                    return Gestures.GetIsHoldWithMouseEnabled(selectable)
+                    return selectable is StyledElement styledElement && InputElement.GetIsHoldWithMouseEnabled(styledElement)
                         ? eventArgs.RoutedEvent == InputElement.PointerReleasedEvent
                         : eventArgs.RoutedEvent == InputElement.PointerPressedEvent;
                 case PointerType.Pen:
@@ -1533,7 +1535,7 @@ namespace Avalonia.Controls
             HasModifiers(eventArgs, GetHotkeys(selectable)?.CommandModifiers);
 
         private static PlatformHotkeyConfiguration? GetHotkeys(Visual element) =>
-            (TopLevel.GetTopLevel(element)?.PlatformSettings ?? Application.Current?.PlatformSettings)?.HotkeyConfiguration;
+            (element.GetPlatformSettings() ?? Application.Current?.PlatformSettings)?.HotkeyConfiguration;
 
         private static bool HasModifiers(RoutedEventArgs eventArgs, KeyModifiers? modifiers)
         {

--- a/src/Avalonia.Controls.ItemsRepeater/Utils/BindingEvaluator.cs
+++ b/src/Avalonia.Controls.ItemsRepeater/Utils/BindingEvaluator.cs
@@ -5,19 +5,19 @@ using Avalonia.Data;
 namespace Avalonia.Controls.Utils
 {
     /// <summary>
-    /// Helper class for evaluating a binding from an Item and IBinding instance.
+    /// Helper class for evaluating a binding from an item and binding instance.
     /// </summary>
-    internal sealed class BindingEvaluator<T> : StyledElement, IDisposable
+    internal sealed class RepeaterBindingEvaluator<T> : StyledElement, IDisposable
     {
         private IDisposable? _expression;
-        private IBinding? _lastBinding;
+        private BindingBase? _lastBinding;
 
         [SuppressMessage(
             "AvaloniaProperty",
             "AVP1002:AvaloniaProperty objects should not be owned by a generic type",
             Justification = "This property is not supposed to be used from XAML.")]
         public static readonly StyledProperty<T> ValueProperty =
-            AvaloniaProperty.Register<BindingEvaluator<T>, T>("Value");
+            AvaloniaProperty.Register<RepeaterBindingEvaluator<T>, T>("Value");
 
         /// <summary>
         /// Gets or sets the data item value.
@@ -36,19 +36,14 @@ namespace Avalonia.Controls.Utils
             return GetValue(ValueProperty);
         }
 
-        public void UpdateBinding(IBinding binding)
+        public void UpdateBinding(BindingBase binding)
         {
             if (binding == _lastBinding)
                 return;
 
             _expression?.Dispose();
             _expression = null;
-
-            var instanced = binding.Initiate(this, ValueProperty);
-            if (instanced is not null)
-            {
-                _expression = BindingOperations.Apply(this, ValueProperty, instanced, null);
-            }
+            _expression = this.Bind(ValueProperty, binding);
             _lastBinding = binding;
         }
 
@@ -63,12 +58,12 @@ namespace Avalonia.Controls.Utils
             DataContext = null;
         }
 
-        public static BindingEvaluator<T>? TryCreate(IBinding? binding)
+        public static RepeaterBindingEvaluator<T>? TryCreate(BindingBase? binding)
         {
             if (binding is null)
                 return null;
 
-            var evaluator = new BindingEvaluator<T>();
+            var evaluator = new RepeaterBindingEvaluator<T>();
             evaluator.UpdateBinding(binding);
             return evaluator;
         }

--- a/tests/Avalonia.Controls.ItemsRepeater.UnitTests/Avalonia.Controls.ItemsRepeater.UnitTests.csproj
+++ b/tests/Avalonia.Controls.ItemsRepeater.UnitTests/Avalonia.Controls.ItemsRepeater.UnitTests.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>ProItemsRepeater.UnitTests</AssemblyName>
+    <RootNamespace>ProItemsRepeater.UnitTests</RootNamespace>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -13,10 +18,7 @@
     <PackageReference Include="Avalonia" Version="$(AvaloniaSampleVersion)" />
     <PackageReference Include="Avalonia.Headless.XUnit" Version="$(AvaloniaSampleVersion)" />
     <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaSampleVersion)" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Avalonia.Controls.ItemsRepeater.UnitTests/ItemsRepeaterDiagnosticsTests.cs
+++ b/tests/Avalonia.Controls.ItemsRepeater.UnitTests/ItemsRepeaterDiagnosticsTests.cs
@@ -9,7 +9,6 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Avalonia.Controls.UnitTests;
 

--- a/tests/Avalonia.Controls.ItemsRepeater.UnitTests/XamlStyleTests.cs
+++ b/tests/Avalonia.Controls.ItemsRepeater.UnitTests/XamlStyleTests.cs
@@ -30,23 +30,23 @@ public class XamlStyleTests
             Brushes.Red, Brushes.Green, Brushes.Blue
         };
 
-        var list = window.FindControl<ItemsRepeater>("list");
+        var list = Assert.IsType<ItemsRepeater>(window.FindControl<ItemsRepeater>("list"));
         list.ItemsSource = collection;
 
         window.Show();
 
-        IEnumerable<IBrush> GetColors() => Enumerable.Range(0, list.ItemsSourceView.Count)
+        IEnumerable<IBrush?> GetColors() => Enumerable.Range(0, list.ItemsSourceView!.Count)
             .Select(t => (list.GetOrCreateElement(t) as TextBlock)!.Foreground);
 
-        Assert.Equal(new[] { Brushes.Transparent, Brushes.Green, Brushes.Transparent }, GetColors());
+        Assert.Equal(new IBrush?[] { Brushes.Transparent, Brushes.Green, Brushes.Transparent }, GetColors());
 
         collection.Remove(Brushes.Green);
 
-        Assert.Equal(new[] { Brushes.Transparent, Brushes.Blue }, GetColors().ToList());
+        Assert.Equal(new IBrush?[] { Brushes.Transparent, Brushes.Blue }, GetColors().ToList());
 
         collection.Add(Brushes.Violet);
         collection.Add(Brushes.Black);
 
-        Assert.Equal(new[] { Brushes.Transparent, Brushes.Blue, Brushes.Transparent, Brushes.Black }, GetColors());
+        Assert.Equal(new IBrush?[] { Brushes.Transparent, Brushes.Blue, Brushes.Transparent, Brushes.Black }, GetColors());
     }
 }


### PR DESCRIPTION
# PR Summary: Upgrade To Avalonia 12.0.0-rc1

## Overview

This change upgrades the repository from Avalonia 11.x to `12.0.0-rc1`, aligns the package version metadata with that release, updates the library code to match Avalonia 12 API changes, and migrates the headless test setup to the xUnit v3 / Microsoft Testing Platform stack now used by `Avalonia.Headless.XUnit`.

The work was split into three focused commits:

1. `fd79782` `chore: upgrade library to Avalonia 12.0.0-rc1`
2. `7a25f2d` `test: migrate headless tests to xunit v3 runner`
3. `275a300` `test: tighten nullable assumptions in XamlStyleTests`

## What Changed

### 1. Shared package and version metadata

- Updated `AvaloniaVersion` and `AvaloniaSampleVersion` to `12.0.0-rc1`.
- Updated package version metadata to publish as `12.0.0-rc1` via:
  - `VersionPrefix=12.0.0`
  - `VersionSuffix=rc1`

Files:

- `Directory.Build.props`
- `build/SharedVersion.props`

### 2. Target framework alignment

Avalonia `12.0.0-rc1` only ships runtime/reference assets for `net8.0` and `net10.0`. The library project was therefore updated to drop the unsupported legacy targets:

- removed `net6.0`
- removed `netstandard2.0`
- kept `net8.0`
- kept `net10.0`

File:

- `src/Avalonia.Controls.ItemsRepeater/Avalonia.Controls.ItemsRepeater.csproj`

### 3. Source compatibility changes for Avalonia 12

Several small API-level changes were needed for the control library to compile against Avalonia 12:

- `SelectedValueBinding` was updated from `IBinding` to `BindingBase`.
- The local binding helper was updated to bind through `AvaloniaObject.Bind(...)` and renamed to `RepeaterBindingEvaluator<T>` to avoid colliding with a similarly named type now present in Avalonia 12.
- `IScrollable` now requires explicit read-only `CanHorizontallyScroll` and `CanVerticallyScroll` implementations, which were added to `ItemsRepeater`.
- Selection input logic was updated to use Avalonia 12 public APIs:
  - `InputElement.GetIsHoldWithMouseEnabled(...)`
  - `element.GetPlatformSettings()`

Files:

- `src/Avalonia.Controls.ItemsRepeater/Controls/ItemsRepeater.LogicalScrollable.cs`
- `src/Avalonia.Controls.ItemsRepeater/Controls/SelectingItemsRepeater.cs`
- `src/Avalonia.Controls.ItemsRepeater/Utils/BindingEvaluator.cs`

### 4. Sample app package graph cleanup

The sample project had a debug-only `Avalonia.Diagnostics` package reference. For `12.0.0-rc1`, that package was not available at the requested version and NuGet was resolving a CI build instead, which caused downgrade/restore failures in the project graph.

Because the sample does not actually use the diagnostics package in source, the debug-only package reference was removed to keep restore/build stable for both Debug and Release.

File:

- `samples/Avalonia.Controls.ItemsRepeater.Samples/Avalonia.Controls.ItemsRepeater.Samples.csproj`

### 5. Test infrastructure migration

`Avalonia.Headless.XUnit` on Avalonia 12 now depends on the xUnit v3 ecosystem. The test project was migrated accordingly:

- removed xUnit v2 packages and old test SDK wiring
- added `xunit.v3`
- switched the test project to `OutputType=Exe`
- enabled Microsoft Testing Platform support for `dotnet test`
- enabled `UseMicrosoftTestingPlatformRunner`
- changed test assembly metadata to avoid a generated namespace collision with the `ItemsRepeater` control type

The assembly/root namespace rename was necessary because the xUnit v3 generated support code was producing a namespace based on the original project name, and that namespace shadowed `Avalonia.Controls.ItemsRepeater` in several tests.

Files:

- `tests/Avalonia.Controls.ItemsRepeater.UnitTests/Avalonia.Controls.ItemsRepeater.UnitTests.csproj`
- `tests/Avalonia.Controls.ItemsRepeater.UnitTests/ItemsRepeaterDiagnosticsTests.cs`

### 6. Test cleanup

`XamlStyleTests` was tightened to make its nullability assumptions explicit and to keep the test compile clean under the upgraded toolchain.

File:

- `tests/Avalonia.Controls.ItemsRepeater.UnitTests/XamlStyleTests.cs`

## Validation

The following commands were executed successfully after the upgrade:

```bash
dotnet build src/Avalonia.Controls.ItemsRepeater/Avalonia.Controls.ItemsRepeater.csproj -c Release
dotnet test tests/Avalonia.Controls.ItemsRepeater.UnitTests/Avalonia.Controls.ItemsRepeater.UnitTests.csproj -c Release
dotnet build samples/Avalonia.Controls.ItemsRepeater.Samples/Avalonia.Controls.ItemsRepeater.Samples.csproj -c Debug
```

Test result:

- `97` passed
- `0` failed
- `0` skipped

## Review Notes

### Main behavioral risk areas

- Binding behavior around `SelectedValueBinding`, since it now routes through `BindingBase` and the updated evaluator path.
- Logical scrolling integration, because Avalonia 12 changed the effective `IScrollable` contract shape.
- Test execution plumbing, because the repo now relies on xUnit v3 + Microsoft Testing Platform rather than the previous xUnit v2 stack.

### Intentional non-goals

- No public API redesign beyond the minimal Avalonia 12 compatibility changes.
- No functional sample app changes beyond stabilizing the package graph.
- No documentation updates outside this summary file.

## Suggested PR Description

Upgrade `ProItemsRepeater` to Avalonia `12.0.0-rc1`, align the package version metadata with the RC, and update the control library for Avalonia 12 API changes. The change also migrates the headless unit test project to xUnit v3 / Microsoft Testing Platform, which is now required by `Avalonia.Headless.XUnit` on Avalonia 12.

This PR includes:

- shared version/property updates for Avalonia `12.0.0-rc1`
- library target framework alignment to `net8.0` and `net10.0`
- source compatibility fixes for binding, scrolling, and platform input/settings APIs
- sample-project restore stabilization by removing the unavailable debug-only diagnostics package
- test harness migration to xUnit v3 and Microsoft Testing Platform
- a small nullable cleanup in one test
